### PR TITLE
Use wl_shm_pool::resize when possible

### DIFF
--- a/include/pool-buffer.h
+++ b/include/pool-buffer.h
@@ -7,6 +7,8 @@
 #include <wayland-client.h>
 
 struct pool_buffer {
+	int poolfd;
+	struct wl_shm_pool *pool;
 	struct wl_buffer *buffer;
 	cairo_surface_t *surface;
 	cairo_t *cairo;


### PR DESCRIPTION
This is a relatively straightforward change, motivated by the fact that almost no applications use the `wl_shm_pool::resize` request, probably because a file descriptor must be kept alive for it to apply. Firefox and mpv contain code that uses the request, but its unclear how, if even, that code can be triggered.