### PR TITLE
Add overdraw and underdraw test clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ ninja -C build
 * `copy-fu`: implements a number of copy-paste behaviors
 * `cursor`: uses buffer position to update a cursor's hotspot
 * `damage-paint`: uses fine-grained damage requests to draw shapes
+* `disobey-resize`: submits buffers in a different size than configured
 * `frame-callback`: requests frame callbacks indefinitely
 * `resizor`: uses buffer position to initiate a client-side resize
 * `slow-ack-configure`: responds to configure events very slowly

--- a/disobey-resize.c
+++ b/disobey-resize.c
@@ -1,0 +1,57 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include "client.h"
+
+static double factor = 0.0;
+static struct wleird_toplevel toplevel = {0};
+static void xdg_toplevel_handle_configure(void *data,
+		struct xdg_toplevel *xdg_toplevel, int32_t w, int32_t h,
+		struct wl_array *states) {
+	struct wleird_toplevel *toplevel = data;
+	if (w == 0 || h == 0) {
+		return;
+	}
+
+	toplevel->surface.width = fmax((double)w * factor, 1);
+	toplevel->surface.height = fmax((double)h * factor, 1);
+}
+
+static int usage(char* bin) {
+	fprintf(stderr, "Usage: %s [size_factor]\n", bin);
+	fprintf(stderr, "size_factor: A floating point factor greater than 0.0 to apply to the requested size\n");
+	return EXIT_FAILURE;
+}
+
+int main(int argc, char *argv[]) {
+	if (argc != 2) {
+		return usage(argv[0]);
+	}
+
+	factor = strtof(argv[1], NULL);
+	if (factor <= 0.0) {
+		return usage(argv[0]);
+	}
+
+	struct wl_display *display = wl_display_connect(NULL);
+	if (display == NULL) {
+		fprintf(stderr, "failed to create display\n");
+		return EXIT_FAILURE;
+	}
+
+	xdg_toplevel_listener.configure = xdg_toplevel_handle_configure;
+
+	registry_init(display);
+	toplevel_init(&toplevel);
+
+	float color[4] = {1, 0, 0, 1};
+	memcpy(toplevel.surface.color, color, sizeof(float[4]));
+
+	while (wl_display_dispatch(display) != -1) {
+		// This space intentionally left blank
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,10 @@ clients = {
 		'src': 'damage-paint.c',
 		'deps': [math],
 	},
+	'disobey-resize': {
+		'src': 'disobey-resize.c',
+		'deps': [math],
+	},
 	'frame-callback': {
 		'src': 'frame-callback.c',
 	},


### PR DESCRIPTION
The overdraw client always submits buffers twice the configured width
and height of its toplevel, while the underdraw client always submits
buffers that are 16x16 regardless of the size of its toplevel.

These clients are useful for discovering geometry issues in a
compositor.