### PR TITLE
Add client that resizes itself indefinitely

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ ninja -C build
 * `damage-paint`: uses fine-grained damage requests to draw shapes
 * `disobey-resize`: submits buffers in a different size than configured
 * `frame-callback`: requests frame callbacks indefinitely
+* `resize-loop`: resizes itself indefinitely
 * `resizor`: uses buffer position to initiate a client-side resize
 * `slow-ack-configure`: responds to configure events very slowly
 * `subsurfaces`: displays a bunch of subsurfaces and lets you reorder them

--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,9 @@ clients = {
 	'frame-callback': {
 		'src': 'frame-callback.c',
 	},
+	'resize-loop': {
+		'src': 'resize-loop.c',
+	},
 	'resizor': {
 		'src': 'resizor.c',
 	},

--- a/resize-loop.c
+++ b/resize-loop.c
@@ -1,0 +1,78 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "client.h"
+
+#define MIN 2
+#define MAX 512
+#define SPEED 10
+static int size = MIN;
+
+static struct wleird_toplevel toplevel = {0};
+static const struct wl_callback_listener callback_listener;
+
+
+static void request_frame_callback(void) {
+	struct wl_callback *callback = wl_surface_frame(toplevel.surface.wl_surface);
+	wl_callback_add_listener(callback, &callback_listener, NULL);
+	wl_surface_commit(toplevel.surface.wl_surface);
+}
+
+static void callback_handle_done(void *data, struct wl_callback *callback,
+		uint32_t time_ms) {
+	if (callback != NULL) {
+		wl_callback_destroy(callback);
+	}
+
+	toplevel.surface.width = abs(size);
+	toplevel.surface.height = abs(size);
+	surface_render(&toplevel.surface);
+
+	size += SPEED;
+	if (size < 0 && size > -MIN) {
+		size = MIN;
+	} else if (size > 0 && size > MAX) {
+		size = -MAX;
+	}
+	request_frame_callback();
+}
+
+static const struct wl_callback_listener callback_listener = {
+	.done = callback_handle_done,
+};
+
+static void xdg_toplevel_handle_configure(void *data,
+		struct xdg_toplevel *xdg_toplevel, int32_t w, int32_t h,
+		struct wl_array *states) {
+	if (w == 0 || h == 0) {
+		return;
+	}
+
+	toplevel.surface.width = abs(size);
+	toplevel.surface.height = abs(size);
+}
+
+int main(int argc, char *argv[]) {
+	struct wl_display *display = wl_display_connect(NULL);
+	if (display == NULL) {
+		fprintf(stderr, "failed to create display\n");
+		return EXIT_FAILURE;
+	}
+
+	xdg_toplevel_listener.configure = xdg_toplevel_handle_configure;
+
+	registry_init(display);
+	toplevel_init(&toplevel);
+
+	float color[4] = {1, 0, 0, 1};
+	memcpy(toplevel.surface.color, color, sizeof(float[4]));
+
+	request_frame_callback();
+
+	while (wl_display_dispatch(display) != -1) {
+		// This space intentionally left blank
+	}
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The resize-loop client continously resizes its buffer in a smooth
motion.

This is useful for discovering geometry issues in compositors caused by
improper handling of client-side resize requests.