### PR TITLE
meson: Prefix executables with 'wleird-'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -95,7 +95,7 @@ clients = {
 
 foreach name, client : clients
 	executable(
-		name,
+		'wleird-' + name,
 		files(client['src']),
 		link_with: lib_client,
 		include_directories: wleird_inc,


### PR DESCRIPTION
This makes them easier to discover when e.g. installed and accessed
via `PATH`, similar to how Weston demo clients are prefixes with
`weston-` or `weston-simple-`.

Closes https://github.com/emersion/wleird/issues/32